### PR TITLE
Update cppCode.ts

### DIFF
--- a/src/cppCode.ts
+++ b/src/cppCode.ts
@@ -27,6 +27,13 @@ const uint8_t data{{this.index}}[{{this.length}}] = { {{this.bytes}} };
 {{#if ../isEtag}}
 const char * etag{{this.index}} = "{{this.md5}}";
 {{/if}}
+{{#if this.isDefault}}
+const uint8_t *defaultDocument = &data{{this.index}}[{{this.length}}];
+const uint lengthDefaultDocument = {{this.length}};
+{{#if ../isEtag}}
+const char * etagDefaultDocument = &etag{{this.index}};
+{{/if}}
+{{/if}}
 {{/each}}
 
 void {{methodName}}(PsychicHttpServer * server) {
@@ -69,6 +76,13 @@ const asyncTemplate = `
 const uint8_t data{{this.index}}[{{this.length}}] PROGMEM = { {{this.bytes}} };
 {{#if ../isEtag}}
 const char * etag{{this.index}} = "{{this.md5}}";
+{{/if}}
+{{#if this.isDefault}}
+const uint8_t *defaultDocument = &data{{this.index}}[{{this.length}}];
+const uint lengthDefaultDocument = {{this.length}};
+{{#if ../isEtag}}
+const char * etagDefaultDocument = &etag{{this.index}};
+{{/if}}
 {{/if}}
 {{/each}}
 


### PR DESCRIPTION
Add some pointers to the default document, so it can be referred to elsewhere by name ("dataDefaultDocument", "lengthDefaultDocument", "etagDefaultDocument").

That way, I can do this to keep SvelteKit routing happy:

server.onNotFound([](AsyncWebServerRequest *request)
                    {
                      if (request->hasHeader("If-None-Match") && request->getHeader("If-None-Match")->value() == String(etagDefaultDocument))
    {
      request->send(304);
      return;
    }
    AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", dataDefaultDocument, lengthDefaultDocument);
    response->addHeader("Content-Encoding", "gzip");
    response->addHeader("ETag", etagDefaultDocument);
    request->send(response); });

You could also rewrite the template that generates the C++ to just give the default document variables a different name rather than adding pointers, but I figured this was just quick and dirty and achieves the same goal.